### PR TITLE
Is there a reason why batdiff isn't included in the Homebrew formula?

### DIFF
--- a/Formula/bat-extras.rb
+++ b/Formula/bat-extras.rb
@@ -20,6 +20,7 @@ class BatExtras < Formula
     bin.install "bin/batgrep" => "batgrep"
     bin.install "bin/batman" => "batman"
     bin.install "bin/batwatch" => "batwatch"
+    bin.install "bin/batdiff" => "batdiff"
     bin.install "bin/prettybat" => "prettybat"
   end
 


### PR DESCRIPTION
When I installed this for the first time, I was surprised to see that batdiff wasn't installed. Looking at the formula, there was a test case for batdiff but batdiff was not actually being installed in the `install` method. I added the line for batdiff and rebuilt from source, and everything seems to work.

Was batdiff explicitly excluded for some reason? If not, this PR adds the installation of batdiff so anyone that uses this formula is not confused when batdiff isn't installed.