### PR TITLE
Updated SHA 256 HASH because of mismatch

### DIFF
--- a/Formula/bat-extras.rb
+++ b/Formula/bat-extras.rb
@@ -2,7 +2,7 @@ class BatExtras < Formula
   desc "Bash scripts that integrate bat with various command-line tools"
   homepage "https://github.com/eth-p/bat-extras"
   url "https://github.com/eth-p/bat-extras/archive/v2023.03.21.tar.gz"
-  sha256 "c2469767c7e76f9d9c4a25574a6ed895754e05410f4ba34f534c148e09dca725"
+  sha256 "27d6b5849448b7cb76404f549f89def9ea1d5adafca85ad39daf25e9ba6ed907"
   head "https://github.com/eth-p/bat-extras.git"
 
   depends_on "bat-extras-batgrep" => :recommended


### PR DESCRIPTION
“
Error: SHA256 mismatch
Expected: c2469767c7e76f9d9c4a25574a6ed895754e05410f4ba34f534c148e09dca725
  Actual: 27d6b5849448b7cb76404f549f89def9ea1d5adafca85ad39daf25e9ba6ed907
    File: /Users/andrew/Library/Caches/Homebrew/downloads/cdecab358b933335f4065c0d8ca204d25dfbd9356e3669f7ac0fbbebeb9740af--bat-extras-2023.03.21.tar.gz
"